### PR TITLE
add `:command` execution support

### DIFF
--- a/sample-config/b/config.toml
+++ b/sample-config/b/config.toml
@@ -12,3 +12,4 @@ margin_left = 0
 margin_right = 0
 width = 400
 height = 800
+command_prefix = ":"

--- a/src/app_entry.rs
+++ b/src/app_entry.rs
@@ -58,6 +58,10 @@ impl AppEntry {
         self.label.set_attributes(Some(&attr_list));
     }
 
+    pub fn hide(&mut self) {
+        self.score = 0;
+    }
+
     fn set_markup(&self, config: &Config) {
         let attr_list = AttrList::new();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,8 @@ make_config!(Config {
     extra_field: Vec<Field> = (vec![Field::IdSuffix]) "extra_field",
     hidden_fields: Vec<Field> = (Vec::new()) "hidden_fields",
     name_overrides: HashMap<String, String> = (HashMap::new()) "name_overrides",
-    hide_extra_if_contained: bool = (true) "hide_extra_if_contained"
+    hide_extra_if_contained: bool = (true) "hide_extra_if_contained",
+    command_prefix: String = (":".into()) "command_prefix"
 });
 
 fn deserialize_markup<'de, D>(deserializer: D) -> Result<Vec<Attribute>, D::Error>

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,8 @@ along with sirula.  If not, see <https://www.gnu.org/licenses/>.
 */
 
 use super::consts::*;
-use glib::{ObjectExt, GString};
+use std::process::Command;
+use glib::{ObjectExt, GString, shell_parse_argv};
 use std::path::PathBuf;
 use gio::{AppInfo, AppInfoExt, AppInfoCreateFlags};
 use gtk::{CssProvider, CssProviderExt};
@@ -39,6 +40,21 @@ pub fn load_css() {
             gtk::STYLE_PROVIDER_PRIORITY_APPLICATION,
         );    
     }
+}
+
+pub fn is_cmd(text: &str, cmd_prefix: &str) -> bool {
+    !cmd_prefix.is_empty() && text.starts_with(cmd_prefix)
+}
+
+pub fn launch_cmd(cmd_line: &str) {
+    let mut parts = shell_parse_argv(cmd_line).expect("Error parsing command line");
+    let mut parts_iter = parts.iter_mut();
+
+    let cmd = parts_iter.next().expect("Expected command");
+
+    let mut child = Command::new(cmd);
+    child.args(parts_iter);
+    child.spawn().expect("Error spawning command");
 }
 
 pub fn launch_app(info: &AppInfo) {


### PR DESCRIPTION
Adds `:command` execution support using `std::process::Command`

This should fix issue #4 

NOTE: this does NOT shell out but just uses spawn directly so no `$ENV` or other glob support. Basic `<cmd> <arg1>..<argN>` only.

Example usage:

`:sudo reboot`