### PR TITLE
Add support for sending environment variables to launched apps

### DIFF
--- a/sample-config/default-config.toml
+++ b/sample-config/default-config.toml
@@ -45,6 +45,9 @@ recent_first = true # sort matches of equal quality by most recently used
 
 # term_command = "alacritty -e {}" # command for applications run in terminal (default uses "$TERMINAL -e")
 
+# send environment variables to the launched app
+send_environment = false
+
 # specify name overrides (id is the name of the desktop file)
 [name_overrides]
 # id = "name\rextra"


### PR DESCRIPTION
## Summary
I was having some issues with settings a qt theme using `qt5ct`, so I implemented an option in the config to send environment variables to apps using GIO's [ApplicationFlags](https://docs.gtk.org/gio/flags.ApplicationFlags.html). 

### Notable Changes
- Added a config option called `send_environment` which controls whether Sirula sends environment variables
- Moved the config variable to the application entry point `main`
- The `app_startup` function now takes (after cloning) ownership over the config variable as a parameter instead of loading it inside the function itself.