### PR TITLE
fix: case insensitive matching

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -118,7 +118,7 @@ fn app_startup(application: &gtk::Application) {
     let matcher = SkimMatcherV2::default();
     let term_command = config.term_command.clone();
     entry.connect_changed(clone!(entries, listbox, cmd_prefix => move |e| {
-        let text = e.text();
+        let text = e.text().to_lowercase();
         let is_cmd = is_cmd(&text, &cmd_prefix);
         {
             let mut entries = entries.borrow_mut();


### PR DESCRIPTION
Hello, hope you don't mind I contribute this quick fix. I noticed that if I use capitol letters when searching, it will bypass app_entries. Adding the to_lower() method to glib::Gstring fixes this problem from what I've tested. 

Let me know if there's a better process to contribute this, I didn't see any guidance in the repo. 

Cheers! 