### PR TITLE
Add option to sort by most frequently used

### DIFF
--- a/sample-config/default-config.toml
+++ b/sample-config/default-config.toml
@@ -41,7 +41,7 @@ exclude = [] # list of regexes for excluded app ids (name of the .desktop file)
 # use "" to disable launching commands
 command_prefix = ":"
 
-frequent_first = true # sort matches of equal quality by most frequently used
+frequent_first = false # sort matches of equal quality by most frequently used
 recent_first = true # sort matches of equal quality by most recently used
 # when both frequent_first and recent_first are set,
 # sorting is by frequency first, and recency is used to break ties in frequency

--- a/sample-config/default-config.toml
+++ b/sample-config/default-config.toml
@@ -41,7 +41,10 @@ exclude = [] # list of regexes for excluded app ids (name of the .desktop file)
 # use "" to disable launching commands
 command_prefix = ":"
 
+frequent_first = true # sort matches of equal quality by most frequently used
 recent_first = true # sort matches of equal quality by most recently used
+# when both frequent_first and recent_first are set,
+# sorting is by frequency first, and recency is used to break ties in frequency
 
 # term_command = "alacritty -e {}" # command for applications run in terminal (default uses "$TERMINAL -e")
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,7 +50,7 @@ make_config!(Config {
     markup_highlight: Vec<Attribute> = (parse_attributes("foreground=\"red\" underline=\"double\"").unwrap()) "markup_highlight" [deserialize_with = "deserialize_markup"],
     markup_extra: Vec<Attribute> = (parse_attributes("font_style=\"italic\" font_size=\"smaller\"").unwrap()) "markup_extra" [deserialize_with = "deserialize_markup"],
     exclusive: bool = (true) "exclusive",
-    frequent_first: bool = (true) "frequent_first",
+    frequent_first: bool = (false) "frequent_first",
     recent_first: bool = (true) "recent_first",
     icon_size: i32 = (64) "icon_size",
     lines: i32 = (2) "lines",

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,6 +50,7 @@ make_config!(Config {
     markup_highlight: Vec<Attribute> = (parse_attributes("foreground=\"red\" underline=\"double\"").unwrap()) "markup_highlight" [deserialize_with = "deserialize_markup"],
     markup_extra: Vec<Attribute> = (parse_attributes("font_style=\"italic\" font_size=\"smaller\"").unwrap()) "markup_extra" [deserialize_with = "deserialize_markup"],
     exclusive: bool = (true) "exclusive",
+    frequent_first: bool = (true) "frequent_first",
     recent_first: bool = (true) "recent_first",
     icon_size: i32 = (64) "icon_size",
     lines: i32 = (2) "lines",

--- a/src/history.rs
+++ b/src/history.rs
@@ -20,8 +20,11 @@ impl PartialEq for HistoryData {
 pub fn load_history() -> HashMap<String, HistoryData> {
     match get_history_file(false) {
         Some(file) => {
-            let config_str = std::fs::read_to_string(file).expect("Cannot read history file");
-            toml::from_str(&config_str).expect("Cannot parse config: {}")
+            let history_str = std::fs::read_to_string(file).expect("Cannot read history file");
+            toml::from_str(&history_str).unwrap_or_else(|err| {
+                eprintln!("Cannot parse history file: {}", err);
+                HashMap::new()
+            })
         },
         _ => HashMap::new()
     }

--- a/src/history.rs
+++ b/src/history.rs
@@ -5,31 +5,42 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use super::util::get_history_file;
 use std::fs::File;
 
-#[derive(Deserialize, Serialize)]
-pub struct History {
-    pub last_used: HashMap<String, u64>
+#[derive(Copy, Clone, Default, Eq, Deserialize, Serialize)]
+pub struct HistoryData {
+    pub last_used : u64,
+    pub usage_count : u32
 }
 
-impl History {
-    pub fn load() -> History {
-        match get_history_file(false) {
-            Some(file) => {
-                let config_str = std::fs::read_to_string(file).expect("Cannot read history file");
-                toml::from_str(&config_str).expect("Cannot parse config: {}")
-            },
-            _ => History { last_used: HashMap::new() }
-        }
+impl PartialEq for HistoryData {
+    fn eq(&self, other: &Self) -> bool {
+        self.last_used.eq(&other.last_used) && self.usage_count.eq(&other.usage_count)
+    }
+}
+
+pub fn load_history() -> HashMap<String, HistoryData> {
+    match get_history_file(false) {
+        Some(file) => {
+            let config_str = std::fs::read_to_string(file).expect("Cannot read history file");
+            toml::from_str(&config_str).expect("Cannot parse config: {}")
+        },
+        _ => HashMap::new()
+    }
+}
+
+pub fn save_history(history: &HashMap<String, HistoryData>) {
+    let file = get_history_file(true).expect("Cannot create history file or cache directory");
+    let mut file = File::create(file).expect("Cannot open history file for writing");
+    let s = toml::to_string(history).unwrap();
+    file.write_all(s.as_bytes()).expect("Cannot write to history file");
+}
+
+pub fn update_history(history: &mut HashMap<String, HistoryData>, id: &str) {
+    let epoch = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards");
+    let usage_count;
+    match history.get(&id.to_string()) {
+        Some(history_match) => { usage_count = history_match.usage_count + 1 },
+        None => { usage_count = 1 }
     }
 
-    pub fn save(&self) {
-        let file = get_history_file(true).expect("Cannot create history file or cache directory");
-        let mut file = File::create(file).expect("Cannot open history file for writing");
-        let s = toml::to_string(self).unwrap();
-        file.write_all(s.as_bytes()).expect("Cannot write to history file");
-    }
-
-    pub fn update(&mut self, id: &str) {
-        let epoch = SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards");
-        self.last_used.insert(id.to_string(), epoch.as_secs());
-    }
+    history.insert( id.to_string(), HistoryData{ last_used: epoch.as_secs(), usage_count } );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,7 +85,7 @@ fn app_startup(application: &gtk::Application) {
     let listbox = gtk::ListBoxBuilder::new().name(LISTBOX_NAME).build();
     scroll.add(&listbox);
 
-    let history = Rc::new(RefCell::new(History::load()));
+    let history = Rc::new(RefCell::new(load_history()));
     let entries = Rc::new(RefCell::new(load_entries(&config, &history.borrow())));
 
     for (row, _) in &entries.borrow() as &HashMap<ListBoxRow, AppEntry> {
@@ -155,8 +155,8 @@ fn app_startup(application: &gtk::Application) {
             launch_app(&e.info, term_command.as_deref());
 
             let mut history = history.borrow_mut();
-            history.update(e.info.id().unwrap().as_str());
-            history.save();
+            update_history(&mut history, e.info.id().unwrap().as_str());
+            save_history(&history);
 
             window.close();
         }


### PR DESCRIPTION
Re-introduce a usage counter, and optionally sort by most frequently used. Also refactors `history.rs` a bit to eliminate `struct History` that just held a `HashMap`.