### PR TITLE
add option to drop old history items

### DIFF
--- a/sample-config/default-config.toml
+++ b/sample-config/default-config.toml
@@ -46,6 +46,9 @@ recent_first = true # sort matches of equal quality by most recently used
 # when both frequent_first and recent_first are set,
 # sorting is by frequency first, and recency is used to break ties in frequency
 
+# if history item is older than this many days, drop it from the history (0 is unset)
+prune_history = 0
+
 # term_command = "alacritty -e {}" # command for applications run in terminal (default uses "$TERMINAL -e")
 
 # specify name overrides (id is the name of the desktop file)

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,7 @@ make_config!(Config {
     exclusive: bool = (true) "exclusive",
     frequent_first: bool = (false) "frequent_first",
     recent_first: bool = (true) "recent_first",
+    prune_history: u32 = (0) "prune_history",
     icon_size: i32 = (64) "icon_size",
     lines: i32 = (2) "lines",
     margin_left: i32 = (0) "margin_left",

--- a/src/main.rs
+++ b/src/main.rs
@@ -89,7 +89,7 @@ fn app_startup(application: &gtk::Application) {
     let listbox = ListBoxBuilder::new().name(LISTBOX_NAME).build();
     scroll.add(&listbox);
 
-    let history = Rc::new(RefCell::new(load_history()));
+    let history = Rc::new(RefCell::new(load_history(config.prune_history)));
     let entries = Rc::new(RefCell::new(load_entries(&config, &history.borrow())));
 
     for row in (&entries.borrow() as &HashMap<ListBoxRow, AppEntry>).keys() {


### PR DESCRIPTION
Adds a config option `prune_history` which will drop history items older than X days.

Default value never drops anything.