### PR TITLE
add option for extra field under name

### DIFF
--- a/sample-config/default-config.toml
+++ b/sample-config/default-config.toml
@@ -31,6 +31,7 @@ height = -1
 
 # specify extra field to be displayed alongside the name (may be empty)
 extra_field = ["id_suffix"] # variants: id, id_suffix, executable, command_line
+extra_field_newline = false # show extra field under name and not alongside
 hide_extra_if_contained = true # hide extra field if it is already contained in the app name
 
 hidden_fields = [] # list of fields considered for search but hidden

--- a/src/app_entry.rs
+++ b/src/app_entry.rs
@@ -192,7 +192,11 @@ pub fn load_entries(
                         || !name.to_lowercase().contains(&e.to_lowercase())) =>
                 {
                     (
-                        format!("{} {}", name, e),
+                        format!("{}{}{}",
+                            name,
+                            if config.extra_field_newline {"\n"} else {" "},
+                            e
+                        ),
                         Some((
                             name.len() as u32 + 1,
                             name.len() as u32 + 1 + e.len() as u32,

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,7 @@ make_config!(Config {
     width: i32 = (-1) "width",
     height: i32 = (-1) "height",
     extra_field: Vec<Field> = (vec![Field::IdSuffix]) "extra_field",
+    extra_field_newline: bool = (false) "extra_field_newline",
     hidden_fields: Vec<Field> = (Vec::new()) "hidden_fields",
     name_overrides: HashMap<String, String> = (HashMap::new()) "name_overrides",
     hide_extra_if_contained: bool = (true) "hide_extra_if_contained",


### PR DESCRIPTION
Add the option for separating the name and the extra field with a newline. Just looks better.